### PR TITLE
Specify any 2.0+ version of Ruby in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby "~> 2.x.x"
+ruby "~> 2.0"
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the


### PR DESCRIPTION
Because Jekyll requires only Ruby 2.0 and we could still have some folks running versions below 2.3, this tweaks the Gemfile config to allow any 2.x.x version.