### PR TITLE
Allow newer Jekyll in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby "~> 2.0"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "3.4.2"
+gem "jekyll", ">= 3.4.2"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (= 3.4.2)
+  jekyll (>= 3.4.2)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
   tzinfo-data


### PR DESCRIPTION
The Gemfile that came from `jekyll new` had a fixed gem version defined. This changes the config to allow for newer versions as well.