### PR TITLE
Use GitHub meta props for some hrefs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@
 title: PWA Stats
 email: info@cloudfour.com
 description: A collection of Progressive Web App case studies.
+repository: cloudfour/pwastats
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: cloudfour

--- a/_includes/contribute-story.html
+++ b/_includes/contribute-story.html
@@ -3,8 +3,7 @@
     <span class="u-inlineBlock u-textGrow1 u-spaceRight u-textNoWrap">
       Help us build this resource!
     </span>
-    <!-- TODO: Add correct URL -->
-    <a class="Button Button--primary u-spaceEnds01 u-textNoWrap" href="#">
+    <a class="Button Button--primary u-spaceEnds01 u-textNoWrap" href="{{ site.github.repository_url }}">
       <svg width="24" height="24" class="Icon Icon--large u-spaceRight06" role="presentation">
         <use xlink:href="#github"/>
       </svg>

--- a/_layouts/error.html
+++ b/_layouts/error.html
@@ -7,9 +7,8 @@ body_class: Sky u-pad1 u-flex u-flexCol u-flexJustifyCenter u-flexAlignItemsCent
 
 <ul class="u-listUnstyled u-spaceTop1 u-spaceItems01">
   <li>
-    <!-- TODO: Add GitHub issues URL -->
     <a class="Button Button--defaultDark u-block u-sizeFull"
-      href="">
+      href="{{ site.github.issues_url }}">
       <svg width="24" height="24" class="Icon Icon--large u-spaceRight06" role="presentation">
         <use xlink:href="#github"/>
       </svg>


### PR DESCRIPTION
Not working for me locally yet, but should work when we make the project public (if I'm reading the docs correctly).

See: https://help.github.com/articles/repository-metadata-on-github-pages/#using-repository-metadata-locally

---

@erikjung @gerardo-rodriguez 