### PR TITLE
More SW stuff

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -72,9 +72,14 @@ self.oninstall = event => {
 };
 
 self.onactivate = event => {
-  event.waitUntil(Promise.all([
-    staticCache.cleanup()
-  ]));
+  caches.keys().then(keys => {
+    keys.forEach(cacheName => {
+      if (!cacheName.endsWith(version)) {
+        caches.delete(cacheName);
+      }
+    });
+  });
+  return event.waitUntil(clients.claim());
 };
 
 router.registerRoutes({


### PR DESCRIPTION
This tidies up a few things with the SW behavior:

- It now only writes to one cache, which will be named `defaultCache_x.x.x` with the current version.
- It will now delete outdated _caches_ based on the version number (opposed to individual entires).