### PR TITLE
Add github url prefixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,10 @@ twitter_username: cloudfour
 github_username: cloudfour
 timezone: America/Los_Angeles
 permalink: /:year/:month/:title/
+
+github:
+  repository_url: https://github.com/cloudfour/pwastats/
+
 defaults:
   -
     scope:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,10 +4,10 @@
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#456BD9">
-  <meta name="msapplication-config" content="/browserconfig.xml">
-  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#456BD9">
+  <meta name="msapplication-config" content="{{ site.github.url }}/browserconfig.xml">
+  <link rel="icon" type="image/png" href="{{ site.github.url }}/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="{{ site.github.url }}/favicon-16x16.png" sizes="16x16">
+  <link rel="mask-icon" href="{{ site.github.url }}/safari-pinned-tab.svg" color="#456BD9">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,400italic|Source+Code+Pro" crossorigin>
   <link rel="stylesheet" href="https://cloudfour-patterns.netlify.com/assets/toolkit/styles/toolkit.css" crossorigin>
   <style>

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -17,9 +17,9 @@
           {% else %}
           <a class="Pagination-item" href=
             {% if page == 1%}
-              "/"
+              "{{ site.github.url }}/"
             {% else %}
-              "{{ site.paginate_path | replace: ':num', page }}"
+              "{{ site.paginate_path | replace: ':num', page | prefix site.github.url }}"
             {% endif %}>
               {% assign pageMinusOne = paginator.page | minus: 1 %}
               {% if page == pageMinusOne %}

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -19,7 +19,7 @@
             {% if page == 1%}
               "{{ site.github.url }}/"
             {% else %}
-              "{{ site.paginate_path | replace: ':num', page | prepend site.github.url }}"
+              "{{ site.paginate_path | replace: ':num', page | prepend:  site.github.url }}"
             {% endif %}>
               {% assign pageMinusOne = paginator.page | minus: 1 %}
               {% if page == pageMinusOne %}

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -19,7 +19,7 @@
             {% if page == 1%}
               "{{ site.github.url }}/"
             {% else %}
-              "{{ site.paginate_path | replace: ':num', page | prefix site.github.url }}"
+              "{{ site.paginate_path | replace: ':num', page | prepend site.github.url }}"
             {% endif %}>
               {% assign pageMinusOne = paginator.page | minus: 1 %}
               {% if page == pageMinusOne %}

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -19,7 +19,7 @@
             {% if page == 1%}
               "{{ site.github.url }}/"
             {% else %}
-              "{{ site.paginate_path | replace: ':num', page | prepend:  site.github.url }}"
+              "{{ site.paginate_path | replace: ':num', page | prepend: site.github.url }}"
             {% endif %}>
               {% assign pageMinusOne = paginator.page | minus: 1 %}
               {% if page == pageMinusOne %}

--- a/_includes/resource-item.html
+++ b/_includes/resource-item.html
@@ -37,7 +37,7 @@
           </time>
         {% else %}
           <a class="Card-metaLink" title="Permalink"
-            href="{{ include.resource.url | prepend site.github.url }}">
+            href="{{ include.resource.url | prepend:  site.github.url }}">
             <svg width="24" height="24" class="Icon Icon--large" role="img">
               <use xlink:href="#link"/>
             </svg>

--- a/_includes/resource-item.html
+++ b/_includes/resource-item.html
@@ -37,7 +37,7 @@
           </time>
         {% else %}
           <a class="Card-metaLink" title="Permalink"
-            href="{{ include.resource.url | prefix site.github.url }}">
+            href="{{ include.resource.url | prepend site.github.url }}">
             <svg width="24" height="24" class="Icon Icon--large" role="img">
               <use xlink:href="#link"/>
             </svg>

--- a/_includes/resource-item.html
+++ b/_includes/resource-item.html
@@ -21,7 +21,7 @@
             {% for tag in include.resource.tags %}
               <li>
                 <a class="Card-metaLink"
-                  href="/tags/{{ tag }}">
+                  href="{{ site.github.url }}/tags/{{ tag }}">
                   #{{ tag }}
                 </a>
               </li>
@@ -37,7 +37,7 @@
           </time>
         {% else %}
           <a class="Card-metaLink" title="Permalink"
-            href="{{ include.resource.url }}">
+            href="{{ include.resource.url | prefix site.github.url }}">
             <svg width="24" height="24" class="Icon Icon--large" role="img">
               <use xlink:href="#link"/>
             </svg>

--- a/_includes/resource-item.html
+++ b/_includes/resource-item.html
@@ -37,7 +37,7 @@
           </time>
         {% else %}
           <a class="Card-metaLink" title="Permalink"
-            href="{{ include.resource.url | prepend:  site.github.url }}">
+            href="{{ include.resource.url | prepend: site.github.url }}">
             <svg width="24" height="24" class="Icon Icon--large" role="img">
               <use xlink:href="#link"/>
             </svg>


### PR DESCRIPTION
This prefixes all links with `site.github.url` in an attempt to resolve the current issue with tags on the deployed site.