### PR TITLE
Exlude package.json from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,3 +61,4 @@ gems:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - package.json


### PR DESCRIPTION
## Overview

This PR adds the `package.json` file to the `exclude` array in the `_config.yml` file.

Closes #40 