### PR TITLE
Omit useless script tag

### DIFF
--- a/_layouts/blank.html
+++ b/_layouts/blank.html
@@ -4,7 +4,6 @@
   <body{% if layout.body_class %} class="{{ layout.body_class }}"{% endif %}>
     {{ content }}
     {% include svg-icons.html %}
-    <script src="{{ site.github.url }}/js/main.js"></script>
     <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('{{ site.github.url }}/sw.js');

--- a/js/main.js
+++ b/js/main.js
@@ -1,1 +1,0 @@
-console.log('main.js');


### PR DESCRIPTION
Since main.js currently does nothing, we can omit it for now.