### PR TITLE
Add scripts for version command

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Don't create a new tag when running `npm version`
+git-tag-version=false

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "install:sw-helpers": "cp node_modules/sw-*/build/sw-*.min.js js/vendor/",
     "postinstall": "npm run install:sw-helpers",
     "preversion": "echo BE SURE TO UPDATE THE VERSION NUMBER IN SW.JS | chalk red bold",
-    "version:bump": "npm --silent version patch",
+    "version:patch": "npm --silent version patch",
     "version:minor": "npm --silent version minor",
     "version:major": "npm --silent version major"
   },

--- a/package.json
+++ b/package.json
@@ -9,11 +9,17 @@
     "sw-routing": "0.0.17",
     "sw-runtime-caching": "0.0.17"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "chalk-cli": "^3.0.0"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "install:sw-helpers": "cp node_modules/sw-*/build/sw-*.min.js js/vendor/",
-    "postinstall": "npm run install:sw-helpers"
+    "postinstall": "npm run install:sw-helpers",
+    "preversion": "echo BE SURE TO UPDATE THE VERSION NUMBER IN SW.JS | chalk red bold",
+    "version:bump": "npm --silent version patch",
+    "version:minor": "npm --silent version minor",
+    "version:major": "npm --silent version major"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds some new `npm version` scripts that will update the package.json version and whine about updating the service worker version as well. 

The `.nvmrc` file contains a flag to disable the default tag-creating behavior of `npm version`, because we are going to do that manually until we figure out a better tagging strategy WRT to content changes.

<img width="616" alt="screen shot 2017-04-06 at 4 11 41 pm" src="https://cloud.githubusercontent.com/assets/61204/24779216/c3a7033c-1ae3-11e7-97ef-d3366f948e12.png">

