### PR TITLE
Add image assets to service worker assetRoute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pwastats",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A collection of Progressive Web App case studies.",
   "dependencies": {
     "sw-lib": "0.0.17",

--- a/sw.js
+++ b/sw.js
@@ -26,7 +26,7 @@ const requestWrapper = new runtimeCaching.RequestWrapper({ cacheName })
  * offline-cookbook/#stale-while-revalidate
  */
 const assetRoute = new routing.RegExpRoute({
-  regExp: new RegExp(`^${localhost}.*\\.(css|js)$`),
+  regExp: new RegExp(`^${localhost}.*\\.(css|js|png|svg)$`),
   handler: new runtimeCaching.StaleWhileRevalidate({ requestWrapper })
 });
 

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@ importScripts(
 );
 
 // Make this always match package.json version
-const version = '0.1.0';
+const version = '0.1.1';
 const cacheName = `defaultCache_${version}`;
 
 const {


### PR DESCRIPTION
## Overview

This PR adds `png` and `svg` to the service worker asset route.

## Screenshots

### Before

<img width="556" alt="screen shot 2017-04-07 at 11 58 29 am" src="https://cloud.githubusercontent.com/assets/459757/24815363/afc3b7c4-1b89-11e7-8d11-746d2ae72e49.png">

### After

<img width="749" alt="screen shot 2017-04-07 at 11 56 39 am" src="https://cloud.githubusercontent.com/assets/459757/24815219/511734f8-1b89-11e7-90c0-1665fb81c555.png">

Closes #71 

---

/CC @cloudfour/pwastats
