### PR TITLE
Add cloudfront CDN assetRoute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pwastats",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A collection of Progressive Web App case studies.",
   "dependencies": {
     "sw-lib": "0.0.17",

--- a/sw.js
+++ b/sw.js
@@ -49,7 +49,7 @@ const externalRoute = new routing.RegExpRoute({
  * https://developers.google.com/web/fundamentals/instant-and-offline/
  * offline-cookbook/#stale-while-revalidate
  */
-const cdnRoute = new routing.RegExpRoute({
+const cdnAssetRoute = new routing.RegExpRoute({
   regExp: new RegExp('^https:\/\/.*\.cloudfront\.net\/.*\.(png|svg)$'),
   handler: new runtimeCaching.StaleWhileRevalidate({ requestWrapper })
 });
@@ -98,7 +98,7 @@ router.registerRoutes({
   routes: [
     assetRoute,
     externalRoute,
-    cdnRoute,
+    cdnAssetRoute,
     navRoute
   ]
 });

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@ importScripts(
 );
 
 // Make this always match package.json version
-const version = '0.1.1';
+const version = '0.1.2';
 const cacheName = `defaultCache_${version}`;
 
 const {

--- a/sw.js
+++ b/sw.js
@@ -43,6 +43,18 @@ const externalRoute = new routing.RegExpRoute({
 });
 
 /**
+ * Route for assets on cloudfront.net CDN
+ *
+ * Strategy:
+ * https://developers.google.com/web/fundamentals/instant-and-offline/
+ * offline-cookbook/#stale-while-revalidate
+ */
+const cdnRoute = new routing.RegExpRoute({
+  regExp: new RegExp('^https:\/\/.*\.cloudfront\.net\/.*\.(png|svg)$'),
+  handler: new runtimeCaching.StaleWhileRevalidate({ requestWrapper })
+});
+
+/**
  * Route for pages
  *
  * Strategy:
@@ -86,6 +98,7 @@ router.registerRoutes({
   routes: [
     assetRoute,
     externalRoute,
+    cdnRoute,
     navRoute
   ]
 });


### PR DESCRIPTION
## Overview

This PR adds a `cdnAssetRoute` to handle the `cloudfront.net` CDN image assets.

See my RegExp in action here: https://regex101.com/r/rwutH0/4

Closes #74 

---

/CC @cloudfour/pwastats
