### PR TITLE
Add site URL to config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ email: info@cloudfour.com
 description: A collection of Progressive Web App case studies.
 repository: cloudfour/pwastats
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://www.pwastats.com" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: cloudfour
 github_username: cloudfour
 timezone: America/Los_Angeles


### PR DESCRIPTION
## Overview

This PR sets the `url` value in the `_config.yml` which, according to the [`jekyll-feed` docs](https://github.com/jekyll/jekyll-feed#usage), will make sure the correct values are used for the feed.

Closes #77 

---

/CC @cloudfour/pwastats
