### PR TITLE
Set default width of Masonry children

### DIFF
--- a/_includes/layout.css
+++ b/_includes/layout.css
@@ -34,6 +34,7 @@ body {
   margin-left: auto;
   margin-right: auto;
   max-width: 40rem;
+  width: 100%;
 }
 
 .Masonry > * + * {


### PR DESCRIPTION
Makes sure cards show up at 100% width when they're on their own row.

---

Fixes #78 

/CC @cloudfour/pwastats
