### PR TITLE
h2 → div for Card-mainContent

### DIFF
--- a/_includes/resource-item.html
+++ b/_includes/resource-item.html
@@ -1,7 +1,7 @@
 <article class="Card u-borderNone">
   <a class="Card-main" href="{{ include.sourceURL }}">
     <h2 class="u-hiddenVisually">
-      {{ post.title }}
+      {{ include.title }}
     </h2>
     {% if include.image %}
     <img class="Card-mainObject" alt=""

--- a/_includes/resource-item.html
+++ b/_includes/resource-item.html
@@ -4,9 +4,9 @@
     <img class="Card-mainObject" alt=""
       src="{{ site.url }}/images/{{ include.image }}">
     {% endif %}
-    <h2 class="Card-mainContent">
+    <div class="Card-mainContent">
       {{ include.content | markdownify }}
-    </h2>
+    </div>
   </a>
   <footer class="Card-meta">
     {% if include.tags.size > 0 %}

--- a/_includes/resource-item.html
+++ b/_includes/resource-item.html
@@ -1,5 +1,8 @@
 <article class="Card u-borderNone">
   <a class="Card-main" href="{{ include.sourceURL }}">
+    <h2 class="u-hiddenVisually">
+      {{ post.title }}
+    </h2>
     {% if include.image %}
     <img class="Card-mainObject" alt=""
       src="{{ site.url }}/images/{{ include.image }}">

--- a/_layouts/permalink.html
+++ b/_layouts/permalink.html
@@ -4,6 +4,7 @@ layout: default
 
 <div class="u-containProse u-md-textGrow1">
   {% include resource-item.html
+    title=page.title
     content=page.content
     date=page.date
     url=page.url

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -11,6 +11,7 @@ layout: default
 <div class="Masonry">
   {% for post in filteredPosts %}
     {% include resource-item.html
+      title=post.title
       content=post.content
       date=post.date
       url=post.url

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@ layout: default
   {% assign posts = paginator.posts | sort: 'date' | reverse %}
   {% for post in posts %}
     {% include resource-item.html
+      title=post.title
       content=post.content
       date=post.date
       url=post.url


### PR DESCRIPTION
Because Markdown wraps the summary in paragraph tags, the containing `h2` was not semantic.

---

Fixes #79

/CC @cloudfour/pwastats
