### PR TITLE
Add default author value

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://www.pwastats.com" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: cloudfour
 github_username: cloudfour
+author: PWA Community
 timezone: America/Los_Angeles
 permalink: /:year/:month/:title/
 


### PR DESCRIPTION
## Overview

This PR adds a default "PWA Community" `author` value for all posts.

Closes #83 

---

/CC @cloudfour/pwastats
