### PR TITLE
ISSUE_TEMPLATE.md (tag directory) link 404

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-> **Note:** This template is for new case study content submissions only. 
+> **Note:** This template is for new case study content submissions only.
 Feel free to replace the outline below if you are submitting a general issue instead.
 
 ---
@@ -16,4 +16,4 @@ e.g. http://example.com/2017/article
 - Tag 1
 - Tag 2
 
-_List all that apply from the [tags directory](../_tags/)._
+_List all that apply from the [tags directory](../tree/master/_tags)._

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "pwastats",
+  "version": "0.1.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "sw-cacheable-response": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/sw-cacheable-response/-/sw-cacheable-response-0.0.18.tgz",
+      "integrity": "sha1-CoI4BThrWF0mQxRznjgZHaghs8w="
+    },
+    "sw-lib": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/sw-lib/-/sw-lib-0.0.17.tgz",
+      "integrity": "sha1-IcokhlFszHSqqywt5w8IRi6NzAs="
+    },
+    "sw-precaching": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/sw-precaching/-/sw-precaching-0.0.17.tgz",
+      "integrity": "sha1-njfo9U1m2unspnIqPwwcKlhHTwM="
+    },
+    "sw-routing": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/sw-routing/-/sw-routing-0.0.17.tgz",
+      "integrity": "sha1-tUt0D+OiKJbzy8HJN68ozre+5L8="
+    },
+    "sw-runtime-caching": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/sw-runtime-caching/-/sw-runtime-caching-0.0.17.tgz",
+      "integrity": "sha1-h8hxyvNAbOsmQwFOG1DnijbR2LE="
+    }
+  }
+}


### PR DESCRIPTION
## Overview

When viewing issues within GH, if you click on the current link referencing the tags directory you get a 404 page not found. 

The link was originally added as `[tags directory](../_tags/)` which is relative to where the ISSUES_TEMPLATE.md lives, yet doesn't work when viewing open issues. 

I changed the URL to `[tags directory](../tree/master/_tags)` and it seems to work. This might not be the best way to link to this file, so I am open to other suggestions. 

## Screenshots

<img width="912" alt="screen shot 2018-01-05 at 8 57 45 am" src="https://user-images.githubusercontent.com/1427548/34619467-15f0edd4-f1f7-11e7-8bb2-f2dbfa77026e.png">


/CC @cloudfour/pwastats
