### PR TITLE
Add a note about installing Ruby and Node/npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This site is built with [Jekyll](https://jekyllrb.com/docs/home/).
 
 ### Quick start
 
+This project relies on [Ruby](https://www.ruby-lang.org/en/), [Node](https://nodejs.org/), and [npm](https://www.npmjs.com/). Before following these steps you'll need to [set up a Ruby dev environment](https://jekyllrb.com/docs/installation/) as well as [install node and npm](https://blog.npmjs.org/post/85484771375/how-to-install-npm) if you haven't already.
+
 ```sh
 git clone git@github.com:cloudfour/pwastats.git
 cd pwastats


### PR DESCRIPTION
When following the install instructions I did not have a custom copy of Ruby installed and it took me a little while to figure out the proper way to install the necessary gems.
MacOS has a global Ruby install that you should not be modifying. Instead your should use something like `rbenv` to set up a dev install.

This commit adds a link to an explanation of how to do so. For completeness sake, it also adds instructions for installing npm.

/CC @cloudfour/pwastats
